### PR TITLE
Fix the intermittent Windows double-build and the Mac codesign identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,13 @@ jobs:
           security import "$WORK/cert.p12" -k "$KC" -P "$P12_PW" -T /usr/bin/codesign -A
           security list-keychains -d user -s "$KC" $(security list-keychains -d user | sed s/\"//g)
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KP" "$KC" >/dev/null
-          IDENTITY="$(security find-identity -v -p codesigning "$KC" | awk 'NR==1{print $2}')"
+          # The CI cert is a self-signed, UNTRUSTED code-signing cert, so `find-identity -v` (valid-only) returns
+          # "0 valid identities found" (CSSMERR_TP_NOT_TRUSTED) and the old awk picked the word "valid", making
+          # `codesign --sign valid` fail with "valid: no identity found". codesign does NOT need the cert trusted,
+          # only present, so select the imported identity by its SHA-1 (list WITHOUT -v). codesign --verify --strict
+          # (the verify step) is a structural seal check and likewise needs no trust.
+          IDENTITY="$(security find-identity -p codesigning "$KC" | grep -oE '[0-9A-F]{40}' | head -1)"
+          if [ -z "$IDENTITY" ]; then echo "::error::No code-signing identity found in the build keychain after import."; exit 1; fi
           for rid in osx-arm64 osx-x64; do
             BIN="src/AgentGuard.Cli/bin/Release/net10.0/$rid/publish/guard"
             codesign --force --options runtime --entitlements eng/signing/agentguard.entitlements --keychain "$KC" --sign "$IDENTITY" "$BIN"

--- a/src/AgentGuard.Cli/AgentGuard.Cli.csproj
+++ b/src/AgentGuard.Cli/AgentGuard.Cli.csproj
@@ -27,8 +27,9 @@
        fallback) pick DIFFERENT per-OS libraries and bundle both. AgentGuardPlatformRid is not on the SDK's strip
        list, so it survives; when no RID is set it is empty and the engine falls back to the build-host OS. -->
   <ItemGroup>
-    <ProjectReference Include="../AgentGuard.Engine/AgentGuard.Engine.csproj"
-                      AdditionalProperties="AgentGuardPlatformRid=$(RuntimeIdentifier)" />
+    <ProjectReference Include="../AgentGuard.Engine/AgentGuard.Engine.csproj">
+      <AdditionalProperties Condition="'$(RuntimeIdentifier)' != ''">AgentGuardPlatformRid=$(RuntimeIdentifier)</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes the two failures the post-merge `dev` run surfaced (they never showed on the PR gate: signing only runs on a merge, and the Windows race is intermittent).

## Windows double-build (the `dev` run's `CS2012 ... used by another process`)
The Cli's `ProjectReference` to the Engine threaded `AgentGuardPlatformRid=$(RuntimeIdentifier)` unconditionally. On a plain no-RID build that sets the global property to the empty string, and "set to empty" is a distinct global-property set from "not set at all" — so every shared library was reached under two configs (the Cli→Engine chain carrying the property, and the solution's own direct build without it) and built **twice** into the same output folder. On Windows the file lock makes the concurrent write fatal; on Mac/Linux it usually slips through.

Fix: thread the property only when `RuntimeIdentifier` is non-empty (a real publish). A plain build no longer forks. **Proven locally** — with the fix each shared library builds once; without it, twice. A real `dotnet publish -r <rid>` threads the RID exactly as before, so per-OS implementation selection is unchanged.

## Mac codesign identity
The sign step selected the identity with `security find-identity -v` (valid-only), which returns nothing for the self-signed CI cert — so it signed with the literal word `valid` and failed. Now selects the imported identity by its SHA-1 (codesign needs the cert present, not trusted).

## Note on proof
This PR's checks run build + test on all three OS (proves the Windows build fix), but **not signing** — signing only runs on the merge to `dev`. So the Mac codesign fix is proven only once this merges and the `dev` signing run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)