### PR TITLE
CI: fix signtool /pa /v flag mangling on the Windows signature verify

### DIFF
--- a/eng/ci-verify-signatures.sh
+++ b/eng/ci-verify-signatures.sh
@@ -44,7 +44,10 @@ ok=1
         ;;
       signtool)
         echo "== signtool verify /pa /v guard-$rid$EXT =="
-        if [ -n "$SIGNTOOL" ] && "$SIGNTOOL" verify /pa /v "$bin" 2>&1; then echo "signtool PASS: $rid"; else echo "signtool FAIL: $rid"; ok=0; fi
+        # MSYS_NO_PATHCONV=1: signtool is a native Windows exe run from Git bash, whose POSIX->Windows path
+        # conversion otherwise rewrites the /pa and /v switches into paths (C:/Program Files/Git/pa, V:/) so they
+        # never reach signtool; without /pa it falls back to a policy that rejects our runner-trusted self-signed cert.
+        if [ -n "$SIGNTOOL" ] && MSYS_NO_PATHCONV=1 "$SIGNTOOL" verify /pa /v "$bin" 2>&1; then echo "signtool PASS: $rid"; else echo "signtool FAIL: $rid"; ok=0; fi
         ;;
       none) ;;
       *) echo "unknown native mode '$NATIVE'"; ok=0 ;;


### PR DESCRIPTION
The `dev` signing run failed on the Windows **verify-signatures** step. The build, the Mac signing, and cosign are all green; only the Windows Authenticode *verify* is red.

## Cause
`eng/ci-verify-signatures.sh` runs signtool (a native Windows exe) from Git bash. Git bash's POSIX→Windows path conversion rewrites the `/pa` and `/v` switches into paths (`C:/Program Files/Git/pa`, `V:/`) before signtool sees them, so the flags never arrive — the "File not found" errors. With `/pa` missing, signtool falls back to a stricter default policy that rejects our self-signed cert, which is the "terminated in a root certificate which is not trusted" error — even though the sign step already installs that cert into the runner's trusted root (`Cert:\LocalMachine\Root`).

## Fix
Prefix the signtool call with `MSYS_NO_PATHCONV=1` so the flags reach signtool; it then chains against the root the sign step installed. One line, in the verify script only.

Signing (and therefore this fix) only runs on the merge to `dev`, so this PR's checks build+test on three OS but do not exercise it — the fix proves out on the `dev` run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)