### PR TITLE
ci: serialize the cross-RID publish check so its double-build cannot race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,16 @@ jobs:
         # Regression guard for scan-resolutions #1: a self-contained cross-RID publish must reference and bundle
         # exactly ONE AgentGuard.CrossPlatform.<OS> library. The per-OS legs can never catch a mis-selection
         # because each job's host matches its RID; this runs a TRUE cross-build (macOS host -> linux-x64 target).
-        run: eng/check-single-platform-lib.sh linux-x64 $AG
+        #
+        # -m:1 (single MSBuild node) is load-bearing, not a preference. A self-contained cross-RID publish evaluates
+        # the same projects twice — once with the RuntimeIdentifier set and once with the SDK's RID stripped for the
+        # app's library references — and both instances write the SAME bin/Release/net10.0 output, because that path
+        # does not vary by RID. Reproduced locally: a plain `dotnet build` builds every project once, while this
+        # publish builds 5 of 7 twice. On parallel nodes the two writers can hit one generated file in the same
+        # instant, which fails the step with "GenerateDepsFile ... deps.json ... used by another process" (seen on
+        # the dev merge of PR #52, run 33440630677). Serializing removes the race; the underlying double-build is
+        # issue #56, and this flag comes out when that is fixed.
+        run: eng/check-single-platform-lib.sh linux-x64 -m:1 $AG
       - name: Test osx-arm64 (native)
         run: dotnet test -c Release $AG --logger "trx;LogFileName=macos-native.trx"
       - name: Test osx-x64 under Rosetta (must run as X64)


### PR DESCRIPTION
`dev` is red. The macOS leg and the gate failed on the merge of PR #52 (run 33440630677) with:

> `error MSB4018: The "GenerateDepsFile" task failed unexpectedly. System.IO.IOException: The process cannot access the file '.../AgentGuard.CrossPlatform.deps.json' because it is being used by another process.`

Same commit, same runner image, macOS green four consecutive times on the PR minutes earlier — a race, not a regression.

## Cause

A self-contained cross-RID publish evaluates the same projects under two global-property sets: `RuntimeIdentifier` set, and the SDK's pass with the RID stripped to build the app's library references (documented in the comment above the `ProjectReference` items in `AgentGuard.Cli.csproj`). Both instances write the same `bin/Release/net10.0` output, because that path does not vary by RID.

Reproduced locally, deterministic:

```
$ eng/check-single-platform-lib.sh linux-x64
   2   AgentGuard.CrossPlatform.Linux
   2   AgentGuard.CrossPlatform
   2   AgentGuard.Cli
   2   AgentGuard.Analyzers
   2   AgentGuard.Abstractions
   1   AgentGuard.Engine
   1   AgentGuard.Boundaries

$ dotnet build -c Release --no-incremental AgentGuard.sln
   every project exactly 1
```

The two that build once are exactly the two the CLI references with the `AgentGuardPlatformRid` threading, which pins them to one property set.

## This change

`-m:1` on that one step, so the two instances serialize. Verified locally: the same publish passes under `-m:1`. It removes the race, not the double-build.

The double-build itself is #56 — a contract-level change to the RID threading that was added to fix a real correctness bug, so it is not rushed in here. The `-m:1` flag comes out when #56 lands.

## Verification

The macOS leg on this PR is the proof: it exercises the changed step on the same runner.